### PR TITLE
try2 bug CryptoTip.sol: Make it Upgrade Safe

### DIFF
--- a/contracts/CryptoTip.sol
+++ b/contracts/CryptoTip.sol
@@ -10,7 +10,7 @@ contract CryptoTip is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     using SafeMathUpgradeable for uint256;
 
     mapping(address => uint256) public balances;
-    uint8 public pushLimit = 10;
+    uint8 public pushLimit;
     uint256 remainder;
 
     event TipsSent(address payable [] teamMembers, uint256 amount);

--- a/contracts/CryptoTip.sol
+++ b/contracts/CryptoTip.sol
@@ -10,7 +10,7 @@ contract CryptoTip is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     using SafeMathUpgradeable for uint256;
 
     mapping(address => uint256) public balances;
-    uint8 public pushLimit = 10;
+    uint8 public pushLimit;
     uint256 remainder;
 
     event TipsSent(address payable [] teamMembers, uint256 amount);
@@ -18,6 +18,7 @@ contract CryptoTip is OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
     function initialize() initializer public {
         __Ownable_init();
+        pushLimit = 10;
     }
 
     function sendTips(address payable[] calldata teamMembers) external payable {
@@ -50,7 +51,7 @@ contract CryptoTip is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             uint amountToSend = amountPerMember;
             require(address(this).balance >= amountToSend, "Insufficient contract balance");
 
-            (bool sent,) = teamMembers[i].call{value : amountToSend}("");
+            (bool sent,) = teamMembers[i].call{value: amountToSend}("");
             require(sent, "Failed to send ETH");
         }
 
@@ -70,7 +71,7 @@ contract CryptoTip is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         require(balance > 0, "No balance to withdraw");
 
         balances[msg.sender] = 0;
-        (bool sent,) = msg.sender.call{value : balance}("");
+        (bool sent,) = msg.sender.call{value: balance}("");
         require(sent, "Failed to send ETH");
         require(balances[msg.sender] == 0, "Failed to zero out balance");
     }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,9 +1,18 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 import "@openzeppelin/hardhat-upgrades";
+import * as dotenv from "dotenv";
 
+dotenv.config();
 const config: HardhatUserConfig = {
   solidity: "0.8.18",
+  defaultNetwork: "goerli",
+  networks: {
+    goerli: {
+      url: process.env.GOERLI_URL,
+      accounts: [process.env.PRIVATE_KEY!],
+    },
+  },
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.2",
-        "@openzeppelin/contracts-upgradeable": "^4.8.2"
+        "@openzeppelin/contracts-upgradeable": "^4.8.2",
+        "dotenv": "^16.0.3"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^2.0.2",
@@ -3502,6 +3503,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -12144,6 +12153,11 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.8.2",
-    "@openzeppelin/contracts-upgradeable": "^4.8.2"
+    "@openzeppelin/contracts-upgradeable": "^4.8.2",
+    "dotenv": "^16.0.3"
   }
 }

--- a/test/CryptoTip.ts
+++ b/test/CryptoTip.ts
@@ -63,7 +63,7 @@ describe("Feature: CryptoTip contract allows users to send and push tips to team
      *      Given See <beforeEach>
      *      When the user sends tips to a list of team members
      *      Then the team members receive the correct amount of ETH
-     *      And the user's wallet balance is updated
+     *      And the user's balance in the smart contract is updated
      */
     it("should allow User can send tips to team members", async function () {
         // User sends tips
@@ -150,6 +150,7 @@ describe("Feature: CryptoTip contract allows users to send and push tips to team
         await expect(cryptoTip.connect(owner).sendTips([], {value: totalAmount})).to.be.revertedWith("Must have at least one team member")
         await expect(cryptoTip.connect(owner).pushTips([], {value: totalAmount})).to.be.revertedWith("Must have at least one team member")
         await expect(cryptoTip.connect(owner).sendTips(teamMembers, {value: totalAmount})).to.not.be.reverted
+        await expect(cryptoTip.connect(owner).pushTips(teamMembers, {value: totalAmount})).to.not.be.reverted
     });
 
     /**


### PR DESCRIPTION
After reading through Alchemy and the links you provided, it looks like a fix to the contract not being upgrade safe is as simple as removing the assignment on line 13. 

`uint8 public pushLimit = 10;` => `uint8 public pushLimit;`